### PR TITLE
Update libc to support loongarch64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,9 +349,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.124"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a41fed9d98f27ab1c6d161da622a4fa35e8a54a8adc24bbf3ddd0ef70b0e50"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "log"


### PR DESCRIPTION
The LoongArch architecture (LoongArch) is an Instruction Set Architecture (ISA) that has a RISC style.
Documentations:
ISA:
https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html
ABI:
https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html
More docs can be found at:
https://loongson.github.io/LoongArch-Documentation/README-EN.html

Due to the lower version of libc, an error occurs when compiling on the loongarch64 architecture:
```
error[E0412]: cannot find type `c_long` in the crate root
  --> /home/alpine/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.124/src/unix/mod.rs:76:24
   |
76 |         pub tv_nsec: ::c_long,
   |                        ^^^^^^ not found in the crate root
   |
help: consider importing this type alias
   |
146+         use ffi::c_long;
   |
help: if you import `c_long`, refer to it directly
   |
76 -         pub tv_nsec: ::c_long,
76 +         pub tv_nsec: c_long,
   |
```